### PR TITLE
[wip] Optional oechem

### DIFF
--- a/boresch_restraints.py
+++ b/boresch_restraints.py
@@ -7,7 +7,6 @@ import mdtraj as md
 import itertools
 from simtk import unit
 from scipy.spatial import distance
-from openeye import oechem
 import math
 from scipy import stats
 #from openforcefield.topology import Molecule
@@ -335,6 +334,8 @@ def check_angle(angle):
     return True
 
 def substructure_search_oechem(mol2_lig, smarts):
+    from openeye import oechem
+
     ifs = oechem.oemolistream(mol2_lig)
 
     mol = oechem.OEGraphMol()
@@ -857,6 +858,7 @@ def analytical_Boresch_correction(r0, thA, thB, fc_r, fc_thA, fc_thB, fc_phiA, f
 
 def ligand_sdf(pdb, outfile):
     ''' Function to get ligand sdf from complex pdb. Only use if no sdf of ligands available. '''
+    from openeye import oechem
 
     complex_A = oechem.OEGraphMol()
     ifs = oechem.oemolistream()

--- a/boresch_restraints.py
+++ b/boresch_restraints.py
@@ -362,7 +362,15 @@ def substructure_search_oechem(mol2_lig, smarts):
 
 
 def substructure_search_rdkit(mol2_lig, smarts):
-    raise NotImplementedError()
+    from rdkit import Chem
+
+    m = Chem.MolFromMol2File(mol2_lig, removeHs=False)
+
+    query = Chem.MolFromSmarts(smarts)
+
+    matches = m.GetSubstructMatches(query, uniquify=True)
+
+    raise matches
 
 
 def substructure_search(mol2_lig, smarts, use_oechem=True):

--- a/boresch_restraints.py
+++ b/boresch_restraints.py
@@ -856,8 +856,8 @@ def analytical_Boresch_correction(r0, thA, thB, fc_r, fc_thA, fc_thB, fc_phiA, f
     dG = dG / 4.184
     return dG
 
-def ligand_sdf(pdb, outfile):
-    ''' Function to get ligand sdf from complex pdb. Only use if no sdf of ligands available. '''
+
+def ligand_sdf_oechem(pdb, outfile):
     from openeye import oechem
 
     complex_A = oechem.OEGraphMol()
@@ -880,3 +880,13 @@ def ligand_sdf(pdb, outfile):
     oechem.OEWriteMolecule(ofs, lig)
 
     return
+
+
+def ligand_sdf(pdb, outfile, use_oechem=True):
+    """Get ligand sdf from complex pdb.
+
+     Only use if no sdf of ligands available."""
+    if use_oechem:
+        return ligand_sdf_oechem(pdb, outfile)
+    else:
+        raise NotImplementedError()

--- a/boresch_restraints.py
+++ b/boresch_restraints.py
@@ -21,19 +21,6 @@ RT = R*T
 
 
 def determine_rings_oechem(lig: str):
-    """Assign atoms into different ring systems
-
-    Parameters
-    ----------
-    lig : str
-      path to the mol2 file
-
-
-    Returns
-    -------
-    atoms
-       for each ring system system, the indices of atoms within
-    """
     from openeye import oechem
 
     # Load in ligand from mol2 into openeye
@@ -56,6 +43,26 @@ def determine_rings_oechem(lig: str):
             atoms.append(single_ring)
 
     return atoms
+
+
+def determine_rings(lig: str, use_oechem=True):
+    """Assign atoms into different ring systems
+
+    Parameters
+    ----------
+    lig : str
+      path to the mol2 file
+
+
+    Returns
+    -------
+    atoms
+       for each ring system system, the indices of atoms within
+    """
+    if use_oechem:
+        return determine_rings_oechem(lig)
+    else:
+        raise NotImplementedError()
 
 
 def select_ligand_atoms(lig, traj, ligand='LIG'):

--- a/boresch_restraints.py
+++ b/boresch_restraints.py
@@ -327,19 +327,7 @@ def check_angle(angle):
         return False
     return True
 
-def substructure_search(mol2_lig, smarts):
-    """Pick ligand atoms for restraints based on substructure search.
-        Parameters
-        ----------
-        mol2_lig : str
-           mol2 file of the ligand.
-        smarts : str
-            Smarts pattern used for substructure search. One atom is flagged and picked for restraints.
-        Returns
-        -------
-        matches: list
-            Indices of ligand atoms that match the picked atom in the substructure.
-        """
+def substructure_search_oechem(mol2_lig, smarts):
     ifs = oechem.oemolistream(mol2_lig)
 
     mol = oechem.OEGraphMol()
@@ -359,6 +347,27 @@ def substructure_search(mol2_lig, smarts):
                 matches.append(matched_atom.target.GetIdx())
 
     return matches
+
+
+def substructure_search(mol2_lig, smarts, use_oechem=True):
+    """Pick ligand atoms for restraints based on substructure search.
+
+    Parameters
+    ----------
+    mol2_lig : str
+       mol2 file of the ligand.
+    smarts : str
+        Smarts pattern used for substructure search. One atom is flagged and picked for restraints.
+
+    Returns
+    -------
+    matches: list
+        Indices of ligand atoms that match the picked atom in the substructure.
+    """
+    if use_oechem:
+        return substructure_search_oechem(mol2_lig, smarts)
+    else:
+        raise NotImplementedError()
 
 
 def select_Boresch_atoms(traj, mol2_lig, ligand_atoms = None, protein_atoms = None, substructure = None, ligand='LIG'):

--- a/boresch_restraints.py
+++ b/boresch_restraints.py
@@ -44,6 +44,10 @@ def determine_rings_oechem(lig: str):
     return atoms
 
 
+def determine_rings_rdkit(lig: str):
+    raise NotImplementedError()
+
+
 def determine_rings(lig: str, use_oechem=True):
     """Assign atoms into different ring systems
 
@@ -61,7 +65,7 @@ def determine_rings(lig: str, use_oechem=True):
     if use_oechem:
         return determine_rings_oechem(lig)
     else:
-        raise NotImplementedError()
+        return determine_rings_rdkit(lig)
 
 
 def select_ligand_atoms(lig, traj, ligand='LIG'):
@@ -357,6 +361,10 @@ def substructure_search_oechem(mol2_lig, smarts):
     return matches
 
 
+def substructure_search_rdkit(mol2_lig, smarts):
+    raise NotImplementedError()
+
+
 def substructure_search(mol2_lig, smarts, use_oechem=True):
     """Pick ligand atoms for restraints based on substructure search.
 
@@ -375,7 +383,7 @@ def substructure_search(mol2_lig, smarts, use_oechem=True):
     if use_oechem:
         return substructure_search_oechem(mol2_lig, smarts)
     else:
-        raise NotImplementedError()
+        return substructure_search_rdkit(mol2_lig, smarts)
 
 
 def select_Boresch_atoms(traj, mol2_lig, ligand_atoms = None, protein_atoms = None, substructure = None, ligand='LIG'):
@@ -882,6 +890,10 @@ def ligand_sdf_oechem(pdb, outfile):
     return
 
 
+def ligand_sdf_rdkit(pdb, outfile):
+    raise NotImplementedError()
+
+
 def ligand_sdf(pdb, outfile, use_oechem=True):
     """Get ligand sdf from complex pdb.
 
@@ -889,4 +901,4 @@ def ligand_sdf(pdb, outfile, use_oechem=True):
     if use_oechem:
         return ligand_sdf_oechem(pdb, outfile)
     else:
-        raise NotImplementedError()
+        return ligand_sdf_rdkit(pdb, outfile)

--- a/combine_coordinates.py
+++ b/combine_coordinates.py
@@ -38,8 +38,16 @@ def align_complexes_oechem(pdb_A, pdb_B, out_B):
     return
 
 
-def align_complexes_rdkit(pdb_A, pdb_B, out_B):
-    raise NotImplementedError()
+def align_complexes_mdtraj(pdb_A, pdb_B, out_B):
+    ref_traj = md.Trajectory(pdb_A)
+    traj = md.Trajectory(pdb_B)
+
+    traj.superpose(ref_traj, atom_indices=ref_traj.topology.select('backbone'))
+
+    with md.formats.PDBTrajectoryFile(out_B, mode='w') as w:
+        w.write(traj.xyz[0], traj.topology,
+                unitcell_lengths=traj.unitcell_lengths[0],
+                unitcell_angles=traj.unitcell_angles[0])
 
 
 def align_complexes(pdb_A, pdb_B, out_B, use_oechem=True):
@@ -52,11 +60,14 @@ def align_complexes(pdb_A, pdb_B, out_B, use_oechem=True):
         pdb structure Complex B
     out_B : str
         pdb structure, Aligned structure of complex B
+    use_oechem : bool
+        if True, will use oechem spruce (requiring license) otherwise will use
+        mdtraj
     """
     if use_oechem:
         return align_complexes_oechem(pdb_A, pdb_B, out_B)
     else:
-        return align_complexes_rdkit(pdb_A, pdb_B, out_B)
+        return align_complexes_mdtraj(pdb_A, pdb_B, out_B)
 
 
 def combine_ligands_gro(in_file_A, in_file_B, out_file, ligand_A='MOL', ligand_B='MOL'):

--- a/combine_coordinates.py
+++ b/combine_coordinates.py
@@ -1,19 +1,11 @@
-from openeye import oechem, oespruce
 import parmed as pmd
 import shutil
 import mdtraj as md
 
-def align_complexes(pdb_A, pdb_B, out_B):
-    """Align 2 structures with oespruce, Structure A is the reference
-    Parameters
-    ----------
-    pdb_A : str
-       pdb structure Complex A
-    pdb_B : str
-        pdb structure Complex B
-    out_B : str
-        pdb structure, Aligned structure of complex B
-    """
+
+def align_complexes_oechem(pdb_A, pdb_B, out_B):
+    from openeye import oechem, oespruce
+
     complex_A = oechem.OEGraphMol()
     ifs = oechem.oemolistream()
     ifs.SetFlavor(oechem.OEFormat_PDB,
@@ -44,6 +36,28 @@ def align_complexes(pdb_A, pdb_B, out_B):
     oechem.OEWriteMolecule(ofs, complex_B)
     ofs.close()
     return
+
+
+def align_complexes_rdkit(pdb_A, pdb_B, out_B):
+    raise NotImplementedError()
+
+
+def align_complexes(pdb_A, pdb_B, out_B, use_oechem=True):
+    """Align 2 structures with oespruce, Structure A is the reference
+    Parameters
+    ----------
+    pdb_A : str
+       pdb structure Complex A
+    pdb_B : str
+        pdb structure Complex B
+    out_B : str
+        pdb structure, Aligned structure of complex B
+    """
+    if use_oechem:
+        return align_complexes_oechem(pdb_A, pdb_B, out_B)
+    else:
+        return align_complexes_rdkit(pdb_A, pdb_B, out_B)
+
 
 def combine_ligands_gro(in_file_A, in_file_B, out_file, ligand_A='MOL', ligand_B='MOL'):
     """Add ligand B coordinates to coordinate (.gro) file of ligand A in complex with protein


### PR DESCRIPTION
This PR includes a non-oechem/oespruce code path for each time one of those functions is called.  (using either rdkit or mdtraj instead).

TODO: I need to double check how mapped atoms in the SMARTS are being used in the substructure search to make sure the rdkit implementation is handling the same.